### PR TITLE
Handling create_at so it complais with MongoDate standard

### DIFF
--- a/src/Ollieread/Multiauth/Passwords/DatabaseTokenRepository.php
+++ b/src/Ollieread/Multiauth/Passwords/DatabaseTokenRepository.php
@@ -121,7 +121,14 @@ class DatabaseTokenRepository implements TokenRepositoryInterface {
 	 */
 	protected function reminderExpired($reminder)
 	{
-		$createdPlusHour = strtotime($reminder->created_at) + $this->expires;
+		if (isset($reminder->created_at)) 
+		{
+			$createdPlusHour = strtotime($reminder->created_at) + $this->expires;
+		} 
+		else 
+		{
+			$createdPlusHour = strtotime($reminder['created_at']['date']) + $this->expires;
+		}
 
 		return $createdPlusHour < $this->getCurrentTime();
 	}


### PR DESCRIPTION
This applys for a projects developed on top of Mongodb. In mongodb create_at is stored as a MongoDat that, looks like this:
~~~json
{
"created_at": {
     "date": "2015-03-31 13:33:07",
     "timezone_type": NumberInt(3),
     "timezone": "UTC"
   } 
}
~~~
Therefor, original check in reminderExpired() of DatabaseTokenRepository throws exception. This pull request fixes the error.

Greetigns